### PR TITLE
Use babel loose mode

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,20 +1,5 @@
 {
   "presets": [
-    [
-      "env",
-      {
-        "targets": {
-          "node": "8"
-        }
-      }
-    ],
-    "react",
-    "stage-2"
-  ],
-  "env": {
-    "test": {
-      "plugins": ["transform-react-jsx-source", "istanbul"]
-    }
-  },
-  "plugins": ["transform-flow-strip-types"]
+    "./.babelrc.js"
+  ]
 }

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,16 @@
+const { NODE_ENV } = process.env
+const test = NODE_ENV === 'test'
+const loose = true
+
+module.exports = {
+  presets: [
+    ['env', test ? { loose, targets: { node: 8 } } : { loose, modules: false }],
+    'react',
+    'stage-2'
+  ],
+  plugins: [
+    'transform-flow-strip-types',
+    test && 'transform-react-jsx-source',
+    test && 'istanbul'
+  ].filter(Boolean)
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -63,8 +63,6 @@ export default {
     commonjs({ include: 'node_modules/**' }),
     babel({
       exclude: 'node_modules/**',
-      babelrc: false,
-      presets: [['env', { modules: false }], 'stage-2'],
       plugins: ['external-helpers']
     }),
     umd


### PR DESCRIPTION
This reduces bundle size a little bit (thanks to loose mode) and keeps babel configs in sync between babelrc and rollup.config.js

es bundle size went down from 2097 to 1903 (gzipped, not minified)
umd.min bundle size went down from 1525 to 1405 (gzipped, minified)

Those numbers assumes ofc that #2 is merged in.