### PR TITLE
Upgrade react-final-form dev dependency to 6.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-final-form-html5-validation",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9479,12 +9479,30 @@
       }
     },
     "react-final-form": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-4.0.2.tgz",
-      "integrity": "sha512-EdFWrT8nMWu5sHViuZ/VmlaYT+mLu/q5TMDWZZj5gnssUAWfgcila0QpptFNDg6+qNtepGgFh5ZPASlivoEXUA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-6.3.0.tgz",
+      "integrity": "sha512-jijhXR1fFGUBQwNOSqF4MK8XJO7Ynl1p8vcFsnQS0INSkGI52+4IagjUgtHj3w8EviIHPFK/Eflji6FELUl07w==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.4.5",
+        "ts-essentials": "^2.0.8"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
+        }
       }
     },
     "react-is": {
@@ -11068,6 +11086,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
       "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
+      "dev": true
+    },
+    "ts-essentials": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
+      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==",
       "dev": true
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "raf": "^3.4.1",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
-    "react-final-form": "^4.0.2",
+    "react-final-form": "^6.3.0",
     "react-test-renderer": "^16.8.1",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",


### PR DESCRIPTION
Tests appear to be broken when testing against react-final-form 6.3.0. Would someone please help fix them?