### PR TITLE
Forward refs to input component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-final-form-html5-validation",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9479,12 +9479,29 @@
       }
     },
     "react-final-form": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-4.0.2.tgz",
-      "integrity": "sha512-EdFWrT8nMWu5sHViuZ/VmlaYT+mLu/q5TMDWZZj5gnssUAWfgcila0QpptFNDg6+qNtepGgFh5ZPASlivoEXUA==",
+      "version": "git+https://github.com/TylerRick/react-final-form.git#6dc92984b5e6c2fa1b5528b944821ffd6951b3ee",
+      "from": "git+https://github.com/TylerRick/react-final-form.git#forwardRef-with_dist",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.4.5",
+        "ts-essentials": "^3.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
+        }
       }
     },
     "react-is": {
@@ -11068,6 +11085,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
       "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
+      "dev": true
+    },
+    "ts-essentials": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-3.0.2.tgz",
+      "integrity": "sha512-vOdAnCS2tt+4fML/Xnf5iWvr+3bAhG0odly05UprbuwgI5hfRhUZ9a+K3hdYSSM0TPRn8/VS3F4Pza1uNqsTKw==",
       "dev": true
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "raf": "^3.4.1",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
-    "react-final-form": "https://github.com/TylerRick/react-final-form.git#forwardRef-with_dist",
+    "react-final-form": "^6.5.0",
     "react-test-renderer": "^16.8.1",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",
@@ -78,11 +78,11 @@
     "rollup-plugin-uglify": "^6.0.2"
   },
   "peerDependencies": {
-    "final-form": ">=4.0.0",
+    "final-form": ">=4.20.0",
     "prop-types": "^15.6.0",
     "react": "^15.3.0 || ^16.0.0-0",
     "react-dom": "^15.3.0 || ^16.0.0-0",
-    "react-final-form": ">=3.0.0"
+    "react-final-form": ">=6.5.0"
   },
   "jest": {
     "testEnvironment": "jsdom"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "raf": "^3.4.1",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
-    "react-final-form": "^4.0.2",
+    "react-final-form": "https://github.com/TylerRick/react-final-form.git#forwardRef-with_dist",
     "react-test-renderer": "^16.8.1",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "start": "nps",
     "test": "nps test",
-    "precommit": "lint-staged && npm start validate"
+    "precommit": "lint-staged && npm start validate",
+    "prepare": "nps build"
   },
   "author": "Erik Rasmussen <rasmussenerik@gmail.com> (http://github.com/erikras)",
   "license": "MIT",

--- a/src/Html5ValidationField.js
+++ b/src/Html5ValidationField.js
@@ -22,7 +22,7 @@ type WithValidity = {
   setCustomValidity: (error: ?string) => void
 }
 
-export default class Html5ValidationField extends React.Component<Props> {
+class Html5ValidationField extends React.Component<Props> {
   props: Props
   input: ?WithValidity
 
@@ -81,9 +81,9 @@ export default class Html5ValidationField extends React.Component<Props> {
         }
         const errorKey: ?string = errorKeys.find(key => (validity: Object)[key])
         let error = errorKey && this.props[errorKey]
-          if (typeof error === 'function') {
-              error = error(value, this.props)
-          }
+        if (typeof error === 'function') {
+          error = error(value, this.props)
+        }
         input.setCustomValidity(error)
         return error
       }
@@ -104,8 +104,20 @@ export default class Html5ValidationField extends React.Component<Props> {
       tooShort,
       typeMismatch,
       valueMissing,
+      innerRef,
       ...rest
     } = this.props
-    return React.createElement(Field, { validate: this.validate, ...rest })
+    return React.createElement(Field, {
+      validate: this.validate,
+      ref: innerRef,
+      ...rest
+    })
   }
 }
+
+export default React.forwardRef((props, ref) => (
+  React.createElement(Html5ValidationField, {
+    innerRef: ref,
+    ...props
+  })
+))

--- a/src/Html5ValidationField.test.js
+++ b/src/Html5ValidationField.test.js
@@ -70,6 +70,22 @@ describe('Html5ValidationField', () => {
     })
   })
 
+  it('should pass ref through to the input', () => {
+    const ref = React.createRef()
+    TestUtils.renderIntoDocument(
+      <Form onSubmit={onSubmitMock} subscription={{ values: true }}>
+        {() => (
+          <form>
+            <Html5ValidationField name="name" component="input" ref={ref} />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(ref.current).not.toBe(null)
+    expect(ref.current instanceof HTMLInputElement).toBe(true)
+  })
+
   describe('Html5ValidationField.messages', () => {
     const testNotPassThrough = message => {
       const consoleSpy = jest
@@ -537,34 +553,43 @@ describe('Html5ValidationField', () => {
         }
       )
     })
-      it('should support functions as default error keys', () => {
-        const setCustomValidity = jest.fn()
-        mockFindNode(
-            {
-                nodeName: 'input',
-                setCustomValidity,
-                validity: {
-                    tooShort: true
-                }
-            },
-            () => {
-              const spy = jest.fn(({ input }) => <input {...input} />)
-              TestUtils.renderIntoDocument(
-                <Form initialValues={{ foo: 'bar' }} onSubmit={onSubmitMock} subscription={{}}>
-                  {() =>
-                      <Html5ValidationField
-                          tooShort={(value, { minLength }) =>
-                              `Value ${value} should have at least ${minLength} characters.`}
-                          minLength={8} name="foo" render={spy} />
+    it('should support functions as default error keys', () => {
+      const setCustomValidity = jest.fn()
+      mockFindNode(
+        {
+          nodeName: 'input',
+          setCustomValidity,
+          validity: {
+            tooShort: true
+          }
+        },
+        () => {
+          const spy = jest.fn(({ input }) => <input {...input} />)
+          TestUtils.renderIntoDocument(
+            <Form
+              initialValues={{ foo: 'bar' }}
+              onSubmit={onSubmitMock}
+              subscription={{}}
+            >
+              {() => (
+                <Html5ValidationField
+                  tooShort={(value, { minLength }) =>
+                    `Value ${value} should have at least ${minLength} characters.`
                   }
-                </Form>
-              )
-              expect(spy).toHaveBeenCalled()
-              expect(spy).toHaveBeenCalledTimes(2)
-              expect(spy.mock.calls[1][0].meta.error).toBe('Value bar should have at least 8 characters.')
-            }
-        )
-      })
+                  minLength={8}
+                  name="foo"
+                  render={spy}
+                />
+              )}
+            </Form>
+          )
+          expect(spy).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalledTimes(2)
+          expect(spy.mock.calls[1][0].meta.error).toBe(
+            'Value bar should have at least 8 characters.'
+          )
+        }
+      )
+    })
   })
-
 })


### PR DESCRIPTION
Follow-up to final-form/react-final-form#608

New test passes, but old tests are failing now against react-final-form 6.3.0 (see #17).